### PR TITLE
Populate RemoteCluster status with remote cluster metadata

### DIFF
--- a/internal/cluster/info.go
+++ b/internal/cluster/info.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Info holds observed cluster metadata.
+type Info struct {
+	ServerVersion string
+	APIEndpoint   string
+	PodCIDR       string
+	ServiceCIDR   string
+	NodeCIDRs     []string
+	NodeCount     int
+}
+
+// Gather connects to the remote cluster using the provided kubeconfig bytes
+// and returns observed cluster metadata.
+func Gather(ctx context.Context, kubeconfig []byte) (*Info, error) {
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot build REST config from kubeconfig")
+	}
+
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create kubernetes clientset")
+	}
+
+	info := &Info{
+		APIEndpoint: cfg.Host,
+	}
+
+	// Server version
+	sv, err := cs.Discovery().ServerVersion()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get server version")
+	}
+	info.ServerVersion = sv.GitVersion
+
+	// Nodes
+	nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot list nodes")
+	}
+	info.NodeCount = len(nodes.Items)
+	for _, node := range nodes.Items {
+		if node.Spec.PodCIDR != "" {
+			info.NodeCIDRs = append(info.NodeCIDRs, node.Spec.PodCIDR)
+		}
+	}
+
+	// Service CIDR from kube-apiserver ClusterIP range (best-effort via "kubernetes" service)
+	svc, err := cs.CoreV1().Services("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err == nil && svc.Spec.ClusterIP != "" {
+		info.ServiceCIDR = svc.Spec.ClusterIP + "/16"
+	}
+
+	// Pod CIDR: use the first node's PodCIDR as a representative
+	if len(nodes.Items) > 0 && nodes.Items[0].Spec.PodCIDR != "" {
+		info.PodCIDR = nodes.Items[0].Spec.PodCIDR
+	}
+
+	return info, nil
+}

--- a/internal/cluster/info_test.go
+++ b/internal/cluster/info_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGatherInvalidKubeconfig(t *testing.T) {
+	_, err := Gather(context.Background(), []byte("not-a-kubeconfig"))
+	if err == nil {
+		t.Fatal("expected error for invalid kubeconfig, got nil")
+	}
+}
+
+func TestGatherEmptyKubeconfig(t *testing.T) {
+	_, err := Gather(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil kubeconfig, got nil")
+	}
+}
+
+func TestGatherUnreachableCluster(t *testing.T) {
+	// Valid kubeconfig format but unreachable server — should fail on server version
+	kc := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:1
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    token: fake
+`)
+	_, err := Gather(context.Background(), kc)
+	if err == nil {
+		t.Fatal("expected error for unreachable cluster, got nil")
+	}
+}

--- a/internal/controller/remotecluster/remotecluster.go
+++ b/internal/controller/remotecluster/remotecluster.go
@@ -44,6 +44,7 @@ import (
 
 	v1alpha1 "github.com/stuttgart-things/provider-kubeconfig/apis/kubeconfig/v1alpha1"
 	apisv1alpha1 "github.com/stuttgart-things/provider-kubeconfig/apis/v1alpha1"
+	clusterpkg "github.com/stuttgart-things/provider-kubeconfig/internal/cluster"
 	decryptpkg "github.com/stuttgart-things/provider-kubeconfig/internal/decrypt"
 	gitpkg "github.com/stuttgart-things/provider-kubeconfig/internal/git"
 )
@@ -396,10 +397,22 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	cr.SetConditions(xpv2.Available())
-	cr.Status.AtProvider = v1alpha1.RemoteClusterObservation{
+	obs := v1alpha1.RemoteClusterObservation{
 		ClusterName: cr.GetName(),
 		SecretRef:   name,
 	}
+
+	// Best-effort: gather remote cluster info from the kubeconfig
+	if info, err := clusterpkg.Gather(ctx, secret.Data["kubeconfig"]); err == nil {
+		obs.ServerVersion = info.ServerVersion
+		obs.APIEndpoint = info.APIEndpoint
+		obs.PodCIDR = info.PodCIDR
+		obs.ServiceCIDR = info.ServiceCIDR
+		obs.NodeCIDRs = info.NodeCIDRs
+		obs.NodeCount = info.NodeCount
+	}
+
+	cr.Status.AtProvider = obs
 
 	return managed.ExternalObservation{
 		ResourceExists:   true,


### PR DESCRIPTION
## Summary
- Add `internal/cluster` package that connects to the remote cluster using the decrypted kubeconfig and gathers: `serverVersion`, `apiEndpoint`, `podCIDR`, `serviceCIDR`, `nodeCIDRs`, `nodeCount`
- Observe populates `status.atProvider` with gathered info on every poll cycle
- Best-effort: if the remote cluster is unreachable, status fields are simply omitted (no error returned)
- The VERSION column in `kubectl get remotecluster` now shows the Kubernetes version

## Test plan
- [x] Unit tests pass (31 tests across all packages)
- [x] `cluster.Gather` tested for invalid kubeconfig, empty kubeconfig, and unreachable cluster
- [ ] E2E: deploy to kind, verify `kubectl get remotecluster` shows VERSION column populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)