### PR TITLE
feat: add semantic-release, Backstage catalog, and techdocs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,14 +8,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
-    name: Build, Push Image & xpkg to GHCR
+  semantic-release:
+    name: Semantic Release
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-go-release.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      stage-image: false
+      push-kustomize: false
+    secrets: inherit # pragma: allowlist secret
+
+  publish:
+    name: Publish Image & xpkg to GHCR
+    needs: semantic-release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     steps:
@@ -25,14 +35,20 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Set build metadata
+      - name: Get latest version tag
         id: meta
         run: |
-          echo "commit=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          git fetch --tags
+          VERSION=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          COMMIT=$(git rev-parse --short HEAD)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
+          echo "Latest version: ${VERSION}, commit: ${COMMIT}"
 
       # --- Container image ---
 
-      - name: Build & push image to ghcr.io (commit tag)
+      - name: Build & push image (version tag)
+        if: steps.meta.outputs.version != ''
         uses: dagger/dagger-for-github@v6
         with:
           version: "0.20.0"
@@ -42,7 +58,7 @@ jobs:
             bake-image
             --src .
             --repository-name stuttgart-things/provider-kubeconfig
-            --tag ${{ steps.meta.outputs.commit }}
+            --tag ${{ steps.meta.outputs.version }}
             --registry-url ghcr.io
             --registry-username env:GITHUB_ACTOR
             --registry-password env:GITHUB_TOKEN
@@ -52,7 +68,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
-      - name: Build & push image to ghcr.io (latest tag)
+      - name: Build & push image (latest tag)
         uses: dagger/dagger-for-github@v6
         with:
           version: "0.20.0"
@@ -83,19 +99,22 @@ jobs:
           sudo mv crossplane /usr/local/bin/
 
       - name: Build xpkg
+        if: steps.meta.outputs.version != ''
         run: |
           crossplane xpkg build \
             --package-root=package \
-            --embed-runtime-image=ghcr.io/stuttgart-things/provider-kubeconfig:${{ steps.meta.outputs.commit }} \
+            --embed-runtime-image=ghcr.io/stuttgart-things/provider-kubeconfig:${{ steps.meta.outputs.version }} \
             -o provider-kubeconfig.xpkg
 
-      - name: Push xpkg (commit tag)
+      - name: Push xpkg (version tag)
+        if: steps.meta.outputs.version != ''
         run: |
           crossplane xpkg push \
-            "ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:${{ steps.meta.outputs.commit }}" \
+            "ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:${{ steps.meta.outputs.version }}" \
             -f provider-kubeconfig.xpkg
 
       - name: Push xpkg (latest tag)
+        if: steps.meta.outputs.version != ''
         run: |
           crossplane xpkg push \
             "ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:latest" \

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,9 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {"preset": "angular"}],
+    ["@semantic-release/release-notes-generator", {"preset": "angular"}],
+    ["@semantic-release/github", {"assets": ["docs/**/*.{pdf,md}"]}]
+  ]
+}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: provider-kubeconfig
+  description: Crossplane Provider that manages remote Kubernetes kubeconfigs from SOPS-encrypted Git repositories
+  annotations:
+    github.com/project-slug: stuttgart-things/xplane-provider-kubeconfig
+    backstage.io/techdocs-ref: url:https://github.com/stuttgart-things/xplane-provider-kubeconfig/tree/main
+    backstage.io/source-location: url:https://github.com/stuttgart-things/xplane-provider-kubeconfig
+  tags:
+    - crossplane
+    - provider
+    - kubeconfig
+    - sops
+    - golang
+  links:
+    - url: https://github.com/stuttgart-things/xplane-provider-kubeconfig
+      title: GitHub Repository
+      icon: github
+spec:
+  type: service
+  lifecycle: experimental
+  owner: platform-team
+  system: crossplane

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,39 @@
+# CI/CD
+
+## GitHub Actions Workflows
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| `build-test` | Push/PR to main | Go build, unit tests, golangci-lint |
+| `build-scan-image` | Push/PR to main | Build container image via Dagger, push to ttl.sh, scan with Trivy |
+| `release` | After image scan on main | Semantic-release, push image + xpkg to ghcr.io |
+
+## Release Process
+
+Releases are automated via [semantic-release](https://semantic-release.gitbook.io/) using the `call-go-release.yaml` reusable workflow:
+
+- `fix:` commits trigger a **patch** bump
+- `feat:` commits trigger a **minor** bump
+- `feat!:` or `BREAKING CHANGE:` commits trigger a **major** bump
+
+Each release:
+
+1. Creates a GitHub release with changelog
+2. Tags the container image at `ghcr.io/stuttgart-things/provider-kubeconfig:<version>`
+3. Builds and pushes the Crossplane xpkg to `ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:<version>`
+
+## Running Tests Locally
+
+```bash
+# Unit tests
+go test ./internal/... -v -count=1
+
+# Build
+go build ./...
+
+# Lint (requires golangci-lint)
+golangci-lint run ./...
+
+# Docker build
+docker build -f cluster/images/provider-kubeconfig/Dockerfile -t provider-kubeconfig:test .
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,76 @@
+# Deployment
+
+## Container Image
+
+The provider image is built as a multi-stage Docker image (Go 1.24 builder + distroless runtime) and pushed to GHCR:
+
+```
+ghcr.io/stuttgart-things/provider-kubeconfig:<commit>
+ghcr.io/stuttgart-things/provider-kubeconfig:latest
+```
+
+## Crossplane xpkg
+
+The Crossplane package (xpkg) embeds the runtime image, CRDs, and package metadata. It is pushed to:
+
+```
+ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:<commit>
+ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:latest
+```
+
+### Install via Crossplane
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubeconfig
+spec:
+  package: ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:latest
+```
+
+### Verify
+
+```bash
+kubectl get providers
+kubectl get remotecluster
+```
+
+## Local Development
+
+```bash
+# Create a kind cluster, install CRDs, and start the provider
+make dev
+
+# Or manually
+kubectl apply -R -f package/crds
+go run cmd/provider/main.go --debug
+
+# Clean up
+make dev-clean
+```
+
+## Encrypting Kubeconfigs
+
+```bash
+# Generate an age key pair
+age-keygen -o age.key
+
+# Encrypt
+sops encrypt --age age1xxx... kubeconfig.yaml > kubeconfig.enc.yaml
+
+# Store the key in Kubernetes
+kubectl create secret generic age-key \
+  --namespace crossplane-system \
+  --from-file=key=age.key
+```
+
+## Provider Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--debug` / `-d` | `false` | Enable debug logging |
+| `--leader-election` / `-l` | `false` | Enable leader election for HA |
+| `--poll` | `1m` | How often to check each resource for drift |
+| `--sync` / `-s` | `1h` | Controller manager sync period |
+| `--max-reconcile-rate` | `10` | Max reconciliations per second |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,84 @@
+# provider-kubeconfig
+
+Crossplane Provider that manages remote Kubernetes cluster kubeconfigs. It reads SOPS-encrypted kubeconfig files from a Git repository, decrypts them, and bootstraps Secrets and downstream ProviderConfigs for the remote clusters.
+
+## Features
+
+- **Git-based kubeconfig management** -- clones/pulls a Git repo and reads encrypted kubeconfig files
+- **SOPS/age decryption** -- decrypts kubeconfigs encrypted with SOPS using age keys
+- **Drift detection** -- compares SHA-256 content hashes on every poll; automatically updates the Secret when the Git file changes
+- **Downstream ProviderConfigs** -- automatically creates `provider-kubernetes` and `provider-helm` ProviderConfig resources referencing the kubeconfig Secret
+- **Remote cluster status** -- gathers metadata from the remote cluster (Kubernetes version, API endpoint, node count, CIDRs)
+
+## Quick Start
+
+### Install via Crossplane xpkg
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubeconfig
+spec:
+  package: ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:latest
+```
+
+### Create Secrets
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: age-key
+  namespace: crossplane-system
+stringData:
+  key: AGE-SECRET-KEY-1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+### Create a ClusterProviderConfig
+
+```yaml
+apiVersion: kubeconfig.stuttgart-things.com/v1alpha1
+kind: ClusterProviderConfig
+metadata:
+  name: default
+spec:
+  git:
+    url: https://github.com/my-org/my-cluster-configs.git
+    branch: main
+  decryption:
+    provider: sops
+    secretRef:
+      name: age-key
+      namespace: crossplane-system
+```
+
+### Create a RemoteCluster
+
+```yaml
+apiVersion: kubeconfig.stuttgart-things.com/v1alpha1
+kind: RemoteCluster
+metadata:
+  name: my-remote-cluster
+spec:
+  forProvider:
+    source:
+      path: clusters/my-cluster/kubeconfig.enc.yaml
+    secretNamespace: crossplane-system
+    providerConfigs:
+      - name: my-cluster-kubernetes
+        type: provider-kubernetes
+      - name: my-cluster-helm
+        type: provider-helm
+  providerConfigRef:
+    name: default
+    kind: ClusterProviderConfig
+```
+
+## Custom Resource Types
+
+| Kind | Scope | Description |
+|------|-------|-------------|
+| `ProviderConfig` | Namespaced | Git + SOPS/age decryption settings (namespaced) |
+| `ClusterProviderConfig` | Cluster | Git + SOPS/age decryption settings (cluster-scoped) |
+| `RemoteCluster` | Cluster | Managed resource -- decrypts kubeconfig, creates Secret + downstream ProviderConfigs |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: provider-kubeconfig
+site_description: Crossplane Provider that manages remote Kubernetes kubeconfigs from SOPS-encrypted Git repositories
+nav:
+  - Home: index.md
+  - Deployment: deployment.md
+  - CI/CD: cicd.md
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
- Add `.releaserc` for semantic-release (angular preset, `v${version}` tag format)
- Add `catalog-info.yaml` for Backstage component registration
- Add `mkdocs.yml` + `docs/` (index.md, deployment.md, cicd.md) for Backstage techdocs
- Update release workflow: semantic-release via `call-go-release.yaml`, then publish versioned image + xpkg to ghcr.io

## After merge
Tag `v0.1.0` manually so semantic-release starts from there (not v1.0.0):
```shell
git tag v0.1.0
git push origin v0.1.0
```

## Release flow
```
main → semantic-release (determines next version)
     → build & push image to ghcr.io:<version> + :latest
     → build & push xpkg to ghcr.io:provider-kubeconfig-xpkg:<version> + :latest
```

## Test plan
- [x] CI passes (build-test + build-scan-image)
- [ ] After v0.1.0 tag, next `feat:` commit should release v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)