### PR TITLE
fix: add .goreleaser.yml to fix release binary builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,20 @@
+version: 2
+builds:
+  - main: ./cmd/provider
+    binary: provider-kubeconfig
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - formats:
+      - tar.gz
+
+changelog:
+  use: github
+  sort: asc


### PR DESCRIPTION
## Summary
GoReleaser failed in the v0.2.0 release because it couldn't find a main package (default scans root, but main is at `cmd/provider`).

- Add `.goreleaser.yml` pointing to `cmd/provider` as main path
- Build for linux/darwin only (amd64 + arm64), no Windows
- CGO_ENABLED=0

## Test plan
- [x] CI passes
- [ ] Next release (v0.2.1) should complete with GoReleaser building binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)