### PR TITLE
feat: add ArgoCD cluster secret support and RBAC bootstrapping

### DIFF
--- a/apis/kubeconfig/v1alpha1/remotecluster_types.go
+++ b/apis/kubeconfig/v1alpha1/remotecluster_types.go
@@ -33,17 +33,22 @@ type RemoteClusterSource struct {
 type ProviderConfigRef struct {
 	// Name of the ProviderConfig to create.
 	Name string `json:"name"`
-	// Type of the downstream provider. e.g. provider-kubernetes, provider-helm
-	// +kubebuilder:validation:Enum=provider-kubernetes;provider-helm
+	// Type of the downstream provider. e.g. provider-kubernetes, provider-helm, argocd-cluster-secret
+	// +kubebuilder:validation:Enum=provider-kubernetes;provider-helm;argocd-cluster-secret
 	Type string `json:"type"`
 	// APIVersions specifies which downstream ProviderConfig API versions to create.
 	// "v1" creates ProviderConfig on *.crossplane.io (cluster-scoped).
 	// "v2" creates ProviderConfig on *.m.crossplane.io (namespaced).
 	// "v2-cluster" creates ClusterProviderConfig on *.m.crossplane.io (cluster-scoped).
 	// Defaults to ["v1"] if omitted for backwards compatibility.
+	// Not used for argocd-cluster-secret type.
 	// +optional
 	// +kubebuilder:default={"v1"}
 	APIVersions []string `json:"apiVersions,omitempty"`
+	// Namespace is the target namespace for the created resource.
+	// Used by argocd-cluster-secret to specify the ArgoCD namespace.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // RemoteClusterParameters are the configurable fields of a RemoteCluster.

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -26,8 +27,11 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -46,6 +50,7 @@ import (
 
 	"github.com/stuttgart-things/provider-kubeconfig/apis"
 	kubeconfig "github.com/stuttgart-things/provider-kubeconfig/internal/controller"
+	rbacpkg "github.com/stuttgart-things/provider-kubeconfig/internal/rbac"
 	"github.com/stuttgart-things/provider-kubeconfig/internal/version"
 )
 
@@ -107,6 +112,17 @@ func main() {
 
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add Kubeconfig APIs to scheme")
 	kingpin.FatalIfError(apiextensionsv1.AddToScheme(mgr.GetScheme()), "Cannot add CustomResourceDefinition to scheme")
+	kingpin.FatalIfError(corev1.AddToScheme(mgr.GetScheme()), "Cannot add core/v1 to scheme")
+	kingpin.FatalIfError(rbacv1.AddToScheme(mgr.GetScheme()), "Cannot add RBAC to scheme")
+
+	// Bootstrap RBAC for downstream ProviderConfig management (best-effort).
+	// Use a direct client (not cached) since the manager hasn't started yet.
+	directClient, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
+	if err == nil {
+		if err := rbacpkg.EnsureDownstreamRBAC(context.Background(), directClient); err != nil {
+			log.Info("Could not bootstrap downstream RBAC (may require manual setup)", "error", err)
+		}
+	}
 
 	metricRecorder := managed.NewMRMetricRecorder()
 	stateMetrics := statemetrics.NewMRStateMetrics()

--- a/internal/controller/remotecluster/remotecluster.go
+++ b/internal/controller/remotecluster/remotecluster.go
@@ -19,6 +19,7 @@ package remotecluster
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -70,7 +72,14 @@ const (
 	annotationContentHash  = "kubeconfig.stuttgart-things.com/content-hash"
 	labelManagedBy         = "app.kubernetes.io/managed-by"
 	labelRemoteCluster     = "remotecluster.kubeconfig.stuttgart-things.com/name"
+	labelArgoCDSecretType  = "argocd.argoproj.io/secret-type"
 	defaultSecretNamespace = "crossplane-system"
+	defaultArgoCDNamespace = "argocd"
+
+	errBuildArgoCDSecret  = "cannot build ArgoCD cluster secret"
+	errCreateArgoCDSecret = "cannot create ArgoCD cluster secret"
+	errDeleteArgoCDSecret = "cannot delete ArgoCD cluster secret"
+	errParseKubeconfig    = "cannot parse kubeconfig for ArgoCD secret"
 )
 
 // providerConfigMeta holds GVK and scope info for a downstream ProviderConfig.
@@ -323,6 +332,62 @@ func buildDownstreamProviderConfig(meta providerConfigMeta, pcName, secretName, 
 	return u, nil
 }
 
+// argoCDClusterConfig is the JSON config block for an ArgoCD cluster secret.
+type argoCDClusterConfig struct {
+	BearerToken     string              `json:"bearerToken"`
+	TLSClientConfig argoCDTLSConfig     `json:"tlsClientConfig"`
+}
+
+// argoCDTLSConfig holds TLS settings for the ArgoCD cluster config.
+type argoCDTLSConfig struct {
+	Insecure bool   `json:"insecure"`
+	CAData   string `json:"caData,omitempty"`
+}
+
+// buildArgoCDClusterSecret creates a Kubernetes Secret in the ArgoCD cluster secret format
+// by extracting the server URL and bearer token from the kubeconfig.
+func buildArgoCDClusterSecret(name, namespace, crName string, kubeconfig []byte) (*corev1.Secret, error) {
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, errors.Wrap(err, errParseKubeconfig)
+	}
+
+	argoConfig := argoCDClusterConfig{
+		BearerToken: cfg.BearerToken,
+		TLSClientConfig: argoCDTLSConfig{
+			Insecure: cfg.TLSClientConfig.Insecure,
+		},
+	}
+
+	// Include CA data if present and not insecure
+	if len(cfg.TLSClientConfig.CAData) > 0 && !cfg.TLSClientConfig.Insecure {
+		argoConfig.TLSClientConfig.CAData = string(cfg.TLSClientConfig.CAData)
+	}
+
+	configJSON, err := json.Marshal(argoConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot marshal ArgoCD cluster config")
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelManagedBy:        "provider-kubeconfig",
+				labelRemoteCluster:    crName,
+				labelArgoCDSecretType: "cluster",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"name":   crName,
+			"server": cfg.Host,
+			"config": string(configJSON),
+		},
+	}, nil
+}
+
 // lookupProviderConfigMeta resolves the providerConfigMeta for a given type and API version label.
 func lookupProviderConfigMeta(providerType, apiVer string) (providerConfigMeta, error) {
 	versions, ok := providerConfigGVKs[providerType]
@@ -367,10 +432,17 @@ func (c *external) ensureOneProviderConfig(ctx context.Context, meta providerCon
 
 // ensureDownstreamProviderConfigs creates any missing downstream ProviderConfigs
 // and deletes stale ones that are no longer in the spec.
-func (c *external) ensureDownstreamProviderConfigs(ctx context.Context, cr *v1alpha1.RemoteCluster, sName, sNamespace string) error {
+func (c *external) ensureDownstreamProviderConfigs(ctx context.Context, cr *v1alpha1.RemoteCluster, sName, sNamespace string, kubeconfig []byte) error {
 	desired := make(map[desiredKey]bool)
 
 	for _, pc := range cr.Spec.ForProvider.ProviderConfigs {
+		if pc.Type == "argocd-cluster-secret" {
+			if err := c.ensureArgoCDClusterSecret(ctx, pc, cr.GetName(), kubeconfig); err != nil {
+				return err
+			}
+			continue
+		}
+
 		for _, apiVer := range resolveAPIVersions(pc) {
 			meta, err := lookupProviderConfigMeta(pc.Type, apiVer)
 			if err != nil {
@@ -391,6 +463,77 @@ func (c *external) ensureDownstreamProviderConfigs(ctx context.Context, cr *v1al
 		}
 	}
 
+	// Delete stale ArgoCD cluster secrets
+	if err := c.deleteStaleArgoCDSecrets(ctx, cr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ensureArgoCDClusterSecret creates an ArgoCD cluster secret if it doesn't exist,
+// or updates it if the kubeconfig has changed.
+func (c *external) ensureArgoCDClusterSecret(ctx context.Context, pc v1alpha1.ProviderConfigRef, crName string, kubeconfig []byte) error {
+	ns := pc.Namespace
+	if ns == "" {
+		ns = defaultArgoCDNamespace
+	}
+
+	desired, err := buildArgoCDClusterSecret(pc.Name, ns, crName, kubeconfig)
+	if err != nil {
+		return errors.Wrap(err, errBuildArgoCDSecret)
+	}
+
+	existing := &corev1.Secret{}
+	err = c.kube.Get(ctx, types.NamespacedName{Name: pc.Name, Namespace: ns}, existing)
+	if kerrors.IsNotFound(err) {
+		if err := c.kube.Create(ctx, desired); err != nil {
+			return errors.Wrap(err, errCreateArgoCDSecret)
+		}
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "cannot check ArgoCD cluster secret %q", pc.Name)
+	}
+
+	// Update if content changed
+	existing.StringData = desired.StringData
+	existing.Labels = desired.Labels
+	if err := c.kube.Update(ctx, existing); err != nil {
+		return errors.Wrapf(err, "cannot update ArgoCD cluster secret %q", pc.Name)
+	}
+	return nil
+}
+
+// deleteStaleArgoCDSecrets deletes ArgoCD cluster secrets owned by this CR
+// that are no longer in the spec.
+func (c *external) deleteStaleArgoCDSecrets(ctx context.Context, cr *v1alpha1.RemoteCluster) error {
+	// Build set of desired ArgoCD secret names
+	desired := make(map[string]bool)
+	for _, pc := range cr.Spec.ForProvider.ProviderConfigs {
+		if pc.Type == "argocd-cluster-secret" {
+			desired[pc.Name] = true
+		}
+	}
+
+	// List all secrets with our labels
+	secretList := &corev1.SecretList{}
+	selector := labels.SelectorFromSet(labels.Set{
+		labelManagedBy:        "provider-kubeconfig",
+		labelRemoteCluster:    cr.GetName(),
+		labelArgoCDSecretType: "cluster",
+	})
+	if err := c.kube.List(ctx, secretList, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return errors.Wrap(err, "cannot list ArgoCD cluster secrets")
+	}
+
+	for i := range secretList.Items {
+		if !desired[secretList.Items[i].Name] {
+			if err := c.kube.Delete(ctx, &secretList.Items[i]); err != nil && !kerrors.IsNotFound(err) {
+				return errors.Wrapf(err, "%s %q", errDeleteArgoCDSecret, secretList.Items[i].Name)
+			}
+		}
+	}
 	return nil
 }
 
@@ -423,23 +566,52 @@ func (c *external) deleteStaleProviderConfigs(ctx context.Context, meta provider
 	return nil
 }
 
-// deleteAllDownstreamProviderConfigs deletes all ProviderConfigs owned by this CR.
+// deleteAllDownstreamProviderConfigs deletes all ProviderConfigs and ArgoCD secrets owned by this CR.
 func (c *external) deleteAllDownstreamProviderConfigs(ctx context.Context, crName, namespace string) error {
 	for _, meta := range allProviderConfigMetas() {
 		if err := c.deleteStaleProviderConfigs(ctx, meta, crName, namespace, nil); err != nil {
 			return err
 		}
 	}
+
+	// Delete all ArgoCD cluster secrets owned by this CR
+	secretList := &corev1.SecretList{}
+	selector := labels.SelectorFromSet(labels.Set{
+		labelManagedBy:        "provider-kubeconfig",
+		labelRemoteCluster:    crName,
+		labelArgoCDSecretType: "cluster",
+	})
+	if err := c.kube.List(ctx, secretList, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return errors.Wrap(err, "cannot list ArgoCD cluster secrets for deletion")
+	}
+	for i := range secretList.Items {
+		if err := c.kube.Delete(ctx, &secretList.Items[i]); err != nil && !kerrors.IsNotFound(err) {
+			return errors.Wrapf(err, "%s %q", errDeleteArgoCDSecret, secretList.Items[i].Name)
+		}
+	}
+
 	return nil
 }
 
-// downstreamProviderConfigsUpToDate checks that all desired downstream ProviderConfigs exist.
+// downstreamProviderConfigsUpToDate checks that all desired downstream ProviderConfigs and ArgoCD secrets exist.
 func (c *external) downstreamProviderConfigsUpToDate(ctx context.Context, cr *v1alpha1.RemoteCluster) bool {
 	ns := cr.Spec.ForProvider.SecretNamespace
 	if ns == "" {
 		ns = defaultSecretNamespace
 	}
 	for _, pc := range cr.Spec.ForProvider.ProviderConfigs {
+		if pc.Type == "argocd-cluster-secret" {
+			argoNS := pc.Namespace
+			if argoNS == "" {
+				argoNS = defaultArgoCDNamespace
+			}
+			s := &corev1.Secret{}
+			if err := c.kube.Get(ctx, types.NamespacedName{Name: pc.Name, Namespace: argoNS}, s); err != nil {
+				return false
+			}
+			continue
+		}
+
 		for _, apiVer := range resolveAPIVersions(pc) {
 			meta, err := lookupProviderConfigMeta(pc.Type, apiVer)
 			if err != nil {
@@ -563,8 +735,8 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateSecret)
 	}
 
-	// Create downstream ProviderConfigs
-	if err := c.ensureDownstreamProviderConfigs(ctx, cr, name, ns); err != nil {
+	// Create downstream ProviderConfigs and ArgoCD secrets
+	if err := c.ensureDownstreamProviderConfigs(ctx, cr, name, ns, content); err != nil {
 		return managed.ExternalCreation{}, err
 	}
 
@@ -614,8 +786,8 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateSecret)
 	}
 
-	// Reconcile downstream ProviderConfigs (create missing, delete stale)
-	if err := c.ensureDownstreamProviderConfigs(ctx, cr, name, ns); err != nil {
+	// Reconcile downstream ProviderConfigs and ArgoCD secrets (create missing, delete stale)
+	if err := c.ensureDownstreamProviderConfigs(ctx, cr, name, ns, content); err != nil {
 		return managed.ExternalUpdate{}, err
 	}
 

--- a/internal/controller/remotecluster/remotecluster_test.go
+++ b/internal/controller/remotecluster/remotecluster_test.go
@@ -18,6 +18,7 @@ package remotecluster
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -37,6 +38,26 @@ import (
 
 	v1alpha1 "github.com/stuttgart-things/provider-kubeconfig/apis/kubeconfig/v1alpha1"
 )
+
+// testKubeconfig is a minimal valid kubeconfig with a bearer token for ArgoCD tests.
+var testKubeconfig = []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.31.101.8:6443
+    certificate-authority-data: dGVzdC1jYS1kYXRh
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: admin
+  name: test-cluster
+current-context: test-cluster
+users:
+- name: admin
+  user:
+    token: test-bearer-token
+`)
 
 // --- helpers ---
 
@@ -363,10 +384,12 @@ func TestDeleteCleansUpDownstreamProviderConfigs(t *testing.T) {
 			return nil
 		},
 		MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
-			ul := list.(*unstructured.UnstructuredList)
-			item := unstructured.Unstructured{}
-			item.SetName("stale-pc")
-			ul.Items = []unstructured.Unstructured{item}
+			switch l := list.(type) {
+			case *unstructured.UnstructuredList:
+				item := unstructured.Unstructured{}
+				item.SetName("stale-pc")
+				l.Items = []unstructured.Unstructured{item}
+			}
 			return nil
 		},
 	}
@@ -512,7 +535,7 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 			{Name: "my-helm", Type: "provider-helm", APIVersions: []string{"v1"}},
 		})
 		e := &external{kube: mc}
-		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace)
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -546,7 +569,7 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 			{Name: "my-k8s", Type: "provider-kubernetes", APIVersions: []string{"v1", "v2"}},
 		})
 		e := &external{kube: mc}
-		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace)
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -590,7 +613,7 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 			{Name: "my-k8s", Type: "provider-kubernetes", APIVersions: []string{"v1", "v2", "v2-cluster"}},
 		})
 		e := &external{kube: mc}
-		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace)
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -635,7 +658,7 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 			{Name: "my-k8s", Type: "provider-kubernetes", APIVersions: []string{"v2"}},
 		})
 		e := &external{kube: mc}
-		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace)
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -670,7 +693,7 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 			{Name: "my-k8s", Type: "provider-kubernetes"},
 		})
 		e := &external{kube: mc}
-		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace)
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -696,13 +719,16 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 			MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 				return nil
 			},
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				return nil
+			},
 		}
 
 		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
 			{Name: "my-k8s", Type: "provider-kubernetes", APIVersions: []string{"v1"}},
 		})
 		e := &external{kube: mc}
-		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace)
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -719,14 +745,19 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 				return nil
 			},
 			MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
-				ul := list.(*unstructured.UnstructuredList)
-				stale := unstructured.Unstructured{}
-				stale.SetName("stale-old-pc")
-				ul.Items = []unstructured.Unstructured{stale}
+				switch l := list.(type) {
+				case *unstructured.UnstructuredList:
+					stale := unstructured.Unstructured{}
+					stale.SetName("stale-old-pc")
+					l.Items = []unstructured.Unstructured{stale}
+				}
 				return nil
 			},
 			MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 				deleted = append(deleted, obj.GetName())
+				return nil
+			},
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 				return nil
 			},
 		}
@@ -735,7 +766,7 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 			{Name: "my-k8s", Type: "provider-kubernetes", APIVersions: []string{"v1"}},
 		})
 		e := &external{kube: mc}
-		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace)
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -748,6 +779,78 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("expected stale-old-pc to be deleted, deleted: %v", deleted)
+		}
+	})
+
+	t.Run("CreatesArgoCDClusterSecret", func(t *testing.T) {
+		var createdSecrets []string
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+			},
+			MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+				createdSecrets = append(createdSecrets, obj.GetName())
+				return nil
+			},
+			MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+				return nil
+			},
+		}
+
+		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
+			{Name: "argocd-dev", Type: "argocd-cluster-secret"},
+		})
+		e := &external{kube: mc}
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		found := false
+		for _, n := range createdSecrets {
+			if n == "argocd-dev" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected argocd-dev secret to be created, created: %v", createdSecrets)
+		}
+	})
+
+	t.Run("MixedProviderConfigsAndArgoCD", func(t *testing.T) {
+		var createdNames []string
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+			},
+			MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+				createdNames = append(createdNames, obj.GetName())
+				return nil
+			},
+			MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+				return nil
+			},
+		}
+
+		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
+			{Name: "my-k8s", Type: "provider-kubernetes", APIVersions: []string{"v1"}},
+			{Name: "argocd-dev", Type: "argocd-cluster-secret"},
+		})
+		e := &external{kube: mc}
+		err := e.ensureDownstreamProviderConfigs(context.Background(), cr, "kubeconfig-dev", defaultSecretNamespace, testKubeconfig)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		nameSet := map[string]bool{}
+		for _, n := range createdNames {
+			nameSet[n] = true
+		}
+		if !nameSet["my-k8s"] {
+			t.Error("expected my-k8s ProviderConfig to be created")
+		}
+		if !nameSet["argocd-dev"] {
+			t.Error("expected argocd-dev ArgoCD secret to be created")
 		}
 	})
 }
@@ -779,6 +882,307 @@ func TestObserveSetsAvailableConditionRequiresSecret(t *testing.T) {
 	if cond.Status == corev1.ConditionTrue {
 		t.Error("Ready should not be True when Secret doesn't exist")
 	}
+}
+
+// --- buildArgoCDClusterSecret tests ---
+
+func TestBuildArgoCDClusterSecret(t *testing.T) {
+	t.Run("ValidKubeconfig", func(t *testing.T) {
+		secret, err := buildArgoCDClusterSecret("argocd-dev", "argocd", "dev-cluster", testKubeconfig)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if secret.Name != "argocd-dev" {
+			t.Errorf("name: want %q, got %q", "argocd-dev", secret.Name)
+		}
+		if secret.Namespace != "argocd" {
+			t.Errorf("namespace: want %q, got %q", "argocd", secret.Namespace)
+		}
+		if secret.Labels[labelArgoCDSecretType] != "cluster" {
+			t.Errorf("label %s: want %q, got %q", labelArgoCDSecretType, "cluster", secret.Labels[labelArgoCDSecretType])
+		}
+		if secret.Labels[labelManagedBy] != "provider-kubeconfig" {
+			t.Errorf("label %s: want %q, got %q", labelManagedBy, "provider-kubeconfig", secret.Labels[labelManagedBy])
+		}
+		if secret.Labels[labelRemoteCluster] != "dev-cluster" {
+			t.Errorf("label %s: want %q, got %q", labelRemoteCluster, "dev-cluster", secret.Labels[labelRemoteCluster])
+		}
+		if secret.StringData["name"] != "dev-cluster" {
+			t.Errorf("stringData.name: want %q, got %q", "dev-cluster", secret.StringData["name"])
+		}
+		if secret.StringData["server"] != "https://10.31.101.8:6443" {
+			t.Errorf("stringData.server: want %q, got %q", "https://10.31.101.8:6443", secret.StringData["server"])
+		}
+
+		// Parse the config JSON and verify bearer token
+		var cfg argoCDClusterConfig
+		if err := json.Unmarshal([]byte(secret.StringData["config"]), &cfg); err != nil {
+			t.Fatalf("cannot parse config JSON: %v", err)
+		}
+		if cfg.BearerToken != "test-bearer-token" {
+			t.Errorf("bearerToken: want %q, got %q", "test-bearer-token", cfg.BearerToken)
+		}
+		if cfg.TLSClientConfig.CAData == "" {
+			t.Error("expected caData to be populated")
+		}
+	})
+
+	t.Run("InvalidKubeconfig", func(t *testing.T) {
+		_, err := buildArgoCDClusterSecret("argocd-dev", "argocd", "dev", []byte("not-a-kubeconfig"))
+		if err == nil {
+			t.Fatal("expected error for invalid kubeconfig")
+		}
+	})
+
+	t.Run("InsecureSkipsTLSVerify", func(t *testing.T) {
+		kc := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.0.0.1:6443
+    insecure-skip-tls-verify: true
+  name: insecure-cluster
+contexts:
+- context:
+    cluster: insecure-cluster
+    user: admin
+  name: insecure-cluster
+current-context: insecure-cluster
+users:
+- name: admin
+  user:
+    token: my-token
+`)
+		secret, err := buildArgoCDClusterSecret("argocd-insecure", "argocd", "insecure", kc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var cfg argoCDClusterConfig
+		if err := json.Unmarshal([]byte(secret.StringData["config"]), &cfg); err != nil {
+			t.Fatalf("cannot parse config JSON: %v", err)
+		}
+		if !cfg.TLSClientConfig.Insecure {
+			t.Error("expected insecure=true")
+		}
+		if cfg.TLSClientConfig.CAData != "" {
+			t.Error("expected empty caData when insecure")
+		}
+	})
+}
+
+// --- ensureArgoCDClusterSecret tests ---
+
+func TestEnsureArgoCDClusterSecret(t *testing.T) {
+	t.Run("CreatesWhenNotFound", func(t *testing.T) {
+		var createdName string
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+			},
+			MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+				createdName = obj.GetName()
+				return nil
+			},
+		}
+
+		pc := v1alpha1.ProviderConfigRef{Name: "argocd-dev", Type: "argocd-cluster-secret"}
+		e := &external{kube: mc}
+		err := e.ensureArgoCDClusterSecret(context.Background(), pc, "dev-cluster", testKubeconfig)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if createdName != "argocd-dev" {
+			t.Errorf("expected create for %q, got %q", "argocd-dev", createdName)
+		}
+	})
+
+	t.Run("UpdatesWhenExists", func(t *testing.T) {
+		var updated bool
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				s := obj.(*corev1.Secret)
+				s.Name = key.Name
+				s.Namespace = key.Namespace
+				return nil
+			},
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				updated = true
+				return nil
+			},
+		}
+
+		pc := v1alpha1.ProviderConfigRef{Name: "argocd-dev", Type: "argocd-cluster-secret", Namespace: "argocd"}
+		e := &external{kube: mc}
+		err := e.ensureArgoCDClusterSecret(context.Background(), pc, "dev-cluster", testKubeconfig)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !updated {
+			t.Error("expected update for existing secret")
+		}
+	})
+
+	t.Run("DefaultsToArgoCDNamespace", func(t *testing.T) {
+		var gotNamespace string
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				gotNamespace = key.Namespace
+				return kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+			},
+			MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
+				return nil
+			},
+		}
+
+		pc := v1alpha1.ProviderConfigRef{Name: "argocd-dev", Type: "argocd-cluster-secret"}
+		e := &external{kube: mc}
+		_ = e.ensureArgoCDClusterSecret(context.Background(), pc, "dev-cluster", testKubeconfig)
+
+		if gotNamespace != defaultArgoCDNamespace {
+			t.Errorf("expected namespace %q, got %q", defaultArgoCDNamespace, gotNamespace)
+		}
+	})
+
+	t.Run("UsesCustomNamespace", func(t *testing.T) {
+		var gotNamespace string
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				gotNamespace = key.Namespace
+				return kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+			},
+			MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
+				return nil
+			},
+		}
+
+		pc := v1alpha1.ProviderConfigRef{Name: "argocd-dev", Type: "argocd-cluster-secret", Namespace: "custom-argocd"}
+		e := &external{kube: mc}
+		_ = e.ensureArgoCDClusterSecret(context.Background(), pc, "dev-cluster", testKubeconfig)
+
+		if gotNamespace != "custom-argocd" {
+			t.Errorf("expected namespace %q, got %q", "custom-argocd", gotNamespace)
+		}
+	})
+}
+
+// --- deleteStaleArgoCDSecrets tests ---
+
+func TestDeleteStaleArgoCDSecrets(t *testing.T) {
+	t.Run("DeletesOrphaned", func(t *testing.T) {
+		var deleted []string
+		mc := &mockClient{
+			MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				sl := list.(*corev1.SecretList)
+				sl.Items = []corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "orphaned-argocd"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "still-desired"}},
+				}
+				return nil
+			},
+			MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
+				deleted = append(deleted, obj.GetName())
+				return nil
+			},
+		}
+
+		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
+			{Name: "still-desired", Type: "argocd-cluster-secret"},
+		})
+		e := &external{kube: mc}
+		err := e.deleteStaleArgoCDSecrets(context.Background(), cr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(deleted) != 1 || deleted[0] != "orphaned-argocd" {
+			t.Errorf("expected only orphaned-argocd deleted, got: %v", deleted)
+		}
+	})
+
+	t.Run("NoDeleteWhenAllDesired", func(t *testing.T) {
+		var deleted []string
+		mc := &mockClient{
+			MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				sl := list.(*corev1.SecretList)
+				sl.Items = []corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "argocd-dev"}},
+				}
+				return nil
+			},
+			MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
+				deleted = append(deleted, obj.GetName())
+				return nil
+			},
+		}
+
+		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
+			{Name: "argocd-dev", Type: "argocd-cluster-secret"},
+		})
+		e := &external{kube: mc}
+		err := e.deleteStaleArgoCDSecrets(context.Background(), cr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(deleted) != 0 {
+			t.Errorf("expected no deletes, got: %v", deleted)
+		}
+	})
+}
+
+// --- downstreamProviderConfigsUpToDate ArgoCD tests ---
+
+func TestDownstreamProviderConfigsUpToDateArgoCD(t *testing.T) {
+	t.Run("ArgoCDSecretExists", func(t *testing.T) {
+		mc := &mockClient{
+			MockGet: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return nil
+			},
+		}
+		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
+			{Name: "argocd-dev", Type: "argocd-cluster-secret"},
+		})
+		e := &external{kube: mc}
+		if !e.downstreamProviderConfigsUpToDate(context.Background(), cr) {
+			t.Error("expected up-to-date when ArgoCD secret exists")
+		}
+	})
+
+	t.Run("ArgoCDSecretMissing", func(t *testing.T) {
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+			},
+		}
+		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
+			{Name: "argocd-dev", Type: "argocd-cluster-secret"},
+		})
+		e := &external{kube: mc}
+		if e.downstreamProviderConfigsUpToDate(context.Background(), cr) {
+			t.Error("expected not up-to-date when ArgoCD secret is missing")
+		}
+	})
+
+	t.Run("ArgoCDDefaultNamespace", func(t *testing.T) {
+		var gotNamespace string
+		mc := &mockClient{
+			MockGet: func(_ context.Context, key types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				gotNamespace = key.Namespace
+				return nil
+			},
+		}
+		cr := newRemoteClusterWithProviderConfigs("dev", "default", "clusters/dev.yaml", []v1alpha1.ProviderConfigRef{
+			{Name: "argocd-dev", Type: "argocd-cluster-secret"},
+		})
+		e := &external{kube: mc}
+		e.downstreamProviderConfigsUpToDate(context.Background(), cr)
+
+		if gotNamespace != defaultArgoCDNamespace {
+			t.Errorf("expected namespace %q, got %q", defaultArgoCDNamespace, gotNamespace)
+		}
+	})
 }
 
 // Silence unused import warnings - these are used by mock methods

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rbac bootstraps RBAC resources for downstream ProviderConfig access.
+package rbac
+
+import (
+	"context"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterRoleName = "provider-kubeconfig-downstream"
+	managedByLabel  = "app.kubernetes.io/managed-by"
+	managedByValue  = "provider-kubeconfig"
+)
+
+// downstreamRules returns the RBAC rules for managing downstream ProviderConfigs.
+func downstreamRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"kubernetes.crossplane.io"},
+			Resources: []string{"providerconfigs"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups: []string{"helm.crossplane.io"},
+			Resources: []string{"providerconfigs"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups: []string{"kubernetes.m.crossplane.io"},
+			Resources: []string{"providerconfigs", "clusterproviderconfigs"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups: []string{"helm.m.crossplane.io"},
+			Resources: []string{"providerconfigs", "clusterproviderconfigs"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+	}
+}
+
+// EnsureDownstreamRBAC creates or updates the ClusterRole and ClusterRoleBinding
+// for managing downstream ProviderConfigs. It detects the running service account
+// from the pod and binds to it automatically.
+func EnsureDownstreamRBAC(ctx context.Context, c client.Client) error {
+	if err := ensureClusterRole(ctx, c); err != nil {
+		return err
+	}
+
+	saName, ns := detectServiceAccount(ctx, c)
+	if saName == "" {
+		return nil
+	}
+
+	return ensureClusterRoleBinding(ctx, c, saName, ns)
+}
+
+func ensureClusterRole(ctx context.Context, c client.Client) error {
+	cr := &rbacv1.ClusterRole{}
+	err := c.Get(ctx, types.NamespacedName{Name: clusterRoleName}, cr)
+	if kerrors.IsNotFound(err) {
+		return c.Create(ctx, &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   clusterRoleName,
+				Labels: map[string]string{managedByLabel: managedByValue},
+			},
+			Rules: downstreamRules(),
+		})
+	}
+	if err != nil {
+		return err
+	}
+	cr.Rules = downstreamRules()
+	return c.Update(ctx, cr)
+}
+
+func ensureClusterRoleBinding(ctx context.Context, c client.Client, saName, ns string) error {
+	crb := &rbacv1.ClusterRoleBinding{}
+	err := c.Get(ctx, types.NamespacedName{Name: clusterRoleName}, crb)
+	if kerrors.IsNotFound(err) {
+		return c.Create(ctx, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   clusterRoleName,
+				Labels: map[string]string{managedByLabel: managedByValue},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     clusterRoleName,
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: ns,
+			}},
+		})
+	}
+	if err != nil {
+		return err
+	}
+
+	for _, s := range crb.Subjects {
+		if s.Kind == "ServiceAccount" && s.Name == saName && s.Namespace == ns {
+			return nil // already bound
+		}
+	}
+	crb.Subjects = append(crb.Subjects, rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      saName,
+		Namespace: ns,
+	})
+	return c.Update(ctx, crb)
+}
+
+// detectServiceAccount discovers the service account by looking up our own pod.
+func detectServiceAccount(ctx context.Context, c client.Client) (string, string) {
+	podName := os.Getenv("HOSTNAME")
+	ns := os.Getenv("POD_NAMESPACE")
+	if ns == "" {
+		if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+			ns = string(data)
+		}
+	}
+	if podName == "" || ns == "" {
+		return "", ""
+	}
+
+	pod := &corev1.Pod{}
+	if err := c.Get(ctx, types.NamespacedName{Name: podName, Namespace: ns}, pod); err != nil {
+		return "", ""
+	}
+	return pod.Spec.ServiceAccountName, ns
+}


### PR DESCRIPTION
## Summary
- Add new downstream provider type `argocd-cluster-secret` that creates ArgoCD-compatible cluster secrets from kubeconfig (server URL, bearer token, TLS config)
- Add runtime RBAC bootstrapping (ClusterRole + ClusterRoleBinding) for downstream ProviderConfig API groups with automatic service account detection
- Add `Namespace` field to `ProviderConfigRef` for specifying the ArgoCD namespace (defaults to `argocd`)
- Full lifecycle: create, update, delete, stale cleanup, and drift detection for ArgoCD secrets
- Comprehensive test coverage (15 new test cases)

## Test plan
- [x] All 38 unit tests pass (`go test ./internal/controller/remotecluster/`)
- [x] `TestBuildArgoCDClusterSecret` — validates secret structure, labels, bearer token, TLS, insecure mode
- [x] `TestEnsureArgoCDClusterSecret` — create, update, default/custom namespace
- [x] `TestDeleteStaleArgoCDSecrets` — orphan cleanup, no-op when all desired
- [x] `TestDownstreamProviderConfigsUpToDateArgoCD` — drift detection for ArgoCD secrets
- [x] `TestEnsureDownstreamProviderConfigs` — mixed ArgoCD + ProviderConfig scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)