### PR TITLE
feat: detect cluster type and write to status

### DIFF
--- a/apis/kubeconfig/v1alpha1/remotecluster_types.go
+++ b/apis/kubeconfig/v1alpha1/remotecluster_types.go
@@ -84,6 +84,8 @@ type RemoteClusterObservation struct {
 	// InternalNetworkKey is the first 3 octets of the node InternalIP network
 	// (e.g. "10.31.102" or "172.18.0"), used as network key for IP reservations.
 	InternalNetworkKey string `json:"internalNetworkKey,omitempty"`
+	// ClusterType is the detected Kubernetes distribution (kind, k3s, rke2, k8s).
+	ClusterType string `json:"clusterType,omitempty"`
 	// SecretRef is the name of the Secret containing the decrypted kubeconfig.
 	SecretRef string `json:"secretRef,omitempty"`
 }
@@ -107,6 +109,7 @@ type RemoteClusterStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".status.atProvider.clusterName"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".status.atProvider.serverVersion"
+// +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".status.atProvider.clusterType"
 // +kubebuilder:printcolumn:name="NETWORK",type="string",JSONPath=".status.atProvider.internalNetworkKey",priority=1
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,kubeconfig}

--- a/internal/cluster/info.go
+++ b/internal/cluster/info.go
@@ -37,6 +37,7 @@ type Info struct {
 	NodeCIDRs          []string
 	NodeCount          int
 	InternalNetworkKey string
+	ClusterType        string
 }
 
 // Gather connects to the remote cluster using the provided kubeconfig bytes
@@ -63,6 +64,8 @@ func Gather(ctx context.Context, kubeconfig []byte) (*Info, error) {
 	}
 
 	gatherServiceCIDR(ctx, cs, info)
+
+	info.ClusterType = detectClusterType(info.ServerVersion, ctx, cs)
 
 	return info, nil
 }
@@ -121,6 +124,35 @@ func internalNetworkKey(nodes []corev1.Node) string {
 		}
 	}
 	return ""
+}
+
+// detectClusterType determines the Kubernetes distribution from the server
+// version string and node metadata. Returns one of: kind, k3s, rke2, k8s.
+func detectClusterType(serverVersion string, ctx context.Context, cs kubernetes.Interface) string {
+	// Check server version for distribution markers
+	if strings.Contains(serverVersion, "+k3s") {
+		return "k3s"
+	}
+	if strings.Contains(serverVersion, "+rke2") {
+		return "rke2"
+	}
+
+	// Check node names/labels for kind clusters
+	nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, node := range nodes.Items {
+			// kind nodes have names like "{cluster}-control-plane" or "{cluster}-worker"
+			if strings.HasSuffix(node.Name, "-control-plane") || strings.HasSuffix(node.Name, "-worker") {
+				// Verify by checking the container runtime — kind uses containerd
+				// and the providerID is empty (no cloud provider)
+				if node.Spec.ProviderID == "" {
+					return "kind"
+				}
+			}
+		}
+	}
+
+	return "k8s"
 }
 
 func gatherServiceCIDR(ctx context.Context, cs kubernetes.Interface, info *Info) {

--- a/internal/cluster/info_test.go
+++ b/internal/cluster/info_test.go
@@ -19,6 +19,11 @@ package cluster
 import (
 	"context"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGatherInvalidKubeconfig(t *testing.T) {
@@ -57,5 +62,82 @@ users:
 	_, err := Gather(context.Background(), kc)
 	if err == nil {
 		t.Fatal("expected error for unreachable cluster, got nil")
+	}
+}
+
+func TestDetectClusterType(t *testing.T) {
+	cases := map[string]struct {
+		serverVersion string
+		nodes         []corev1.Node
+		want          string
+	}{
+		"K3sVersion": {
+			serverVersion: "v1.31.4+k3s1",
+			want:          "k3s",
+		},
+		"RKE2Version": {
+			serverVersion: "v1.31.4+rke2r1",
+			want:          "rke2",
+		},
+		"KindCluster": {
+			serverVersion: "v1.35.0",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-cluster-control-plane"},
+					Spec:       corev1.NodeSpec{ProviderID: ""},
+				},
+			},
+			want: "kind",
+		},
+		"KindWorkerNode": {
+			serverVersion: "v1.35.0",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-worker"},
+					Spec:       corev1.NodeSpec{ProviderID: ""},
+				},
+			},
+			want: "kind",
+		},
+		"CloudNodeNotKind": {
+			serverVersion: "v1.35.0",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-control-plane"},
+					Spec:       corev1.NodeSpec{ProviderID: "aws://us-east-1/i-abc123"},
+				},
+			},
+			want: "k8s",
+		},
+		"GenericK8s": {
+			serverVersion: "v1.35.0",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				},
+			},
+			want: "k8s",
+		},
+		"NoNodes": {
+			serverVersion: "v1.35.0",
+			want:          "k8s",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			objs := make([]corev1.Node, len(tc.nodes))
+			copy(objs, tc.nodes)
+
+			cs := fake.NewSimpleClientset()
+			for i := range objs {
+				_, _ = cs.CoreV1().Nodes().Create(context.Background(), &objs[i], metav1.CreateOptions{})
+			}
+
+			got := detectClusterType(tc.serverVersion, context.Background(), cs)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("-want, +got:\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/controller/remotecluster/remotecluster.go
+++ b/internal/controller/remotecluster/remotecluster.go
@@ -684,6 +684,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		obs.NodeCIDRs = info.NodeCIDRs
 		obs.NodeCount = info.NodeCount
 		obs.InternalNetworkKey = info.InternalNetworkKey
+		obs.ClusterType = info.ClusterType
 	}
 
 	cr.Status.AtProvider = obs


### PR DESCRIPTION
## Summary
- Adds `ClusterType` field to `RemoteClusterObservation` detecting `kind`, `k3s`, `rke2`, or `k8s`
- Detection uses server version string (`+k3s`, `+rke2`) and node metadata (name suffix + empty providerID for kind)
- Adds `TYPE` print column to `kubectl get remotecluster` output
- Includes 7 unit tests covering all detection paths

Closes #31

## Test plan
- [ ] Deploy to kind cluster — verify TYPE shows `kind`
- [ ] Test with k3s kubeconfig — verify TYPE shows `k3s`
- [ ] `kubectl get remotecluster` shows TYPE column

🤖 Generated with [Claude Code](https://claude.com/claude-code)