### PR TITLE
fix: resolve golangci-lint v2 issues

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -31,8 +31,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 

--- a/internal/controller/remotecluster/remotecluster.go
+++ b/internal/controller/remotecluster/remotecluster.go
@@ -334,8 +334,8 @@ func buildDownstreamProviderConfig(meta providerConfigMeta, pcName, secretName, 
 
 // argoCDClusterConfig is the JSON config block for an ArgoCD cluster secret.
 type argoCDClusterConfig struct {
-	BearerToken     string              `json:"bearerToken"`
-	TLSClientConfig argoCDTLSConfig     `json:"tlsClientConfig"`
+	BearerToken     string          `json:"bearerToken"`
+	TLSClientConfig argoCDTLSConfig `json:"tlsClientConfig"`
 }
 
 // argoCDTLSConfig holds TLS settings for the ArgoCD cluster config.
@@ -355,13 +355,13 @@ func buildArgoCDClusterSecret(name, namespace, crName string, kubeconfig []byte)
 	argoConfig := argoCDClusterConfig{
 		BearerToken: cfg.BearerToken,
 		TLSClientConfig: argoCDTLSConfig{
-			Insecure: cfg.TLSClientConfig.Insecure,
+			Insecure: cfg.Insecure,
 		},
 	}
 
 	// Include CA data if present and not insecure
-	if len(cfg.TLSClientConfig.CAData) > 0 && !cfg.TLSClientConfig.Insecure {
-		argoConfig.TLSClientConfig.CAData = string(cfg.TLSClientConfig.CAData)
+	if len(cfg.CAData) > 0 && !cfg.Insecure {
+		argoConfig.TLSClientConfig.CAData = string(cfg.CAData)
 	}
 
 	configJSON, err := json.Marshal(argoConfig)

--- a/internal/controller/remotecluster/remotecluster_test.go
+++ b/internal/controller/remotecluster/remotecluster_test.go
@@ -384,8 +384,7 @@ func TestDeleteCleansUpDownstreamProviderConfigs(t *testing.T) {
 			return nil
 		},
 		MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
-			switch l := list.(type) {
-			case *unstructured.UnstructuredList:
+			if l, ok := list.(*unstructured.UnstructuredList); ok {
 				item := unstructured.Unstructured{}
 				item.SetName("stale-pc")
 				l.Items = []unstructured.Unstructured{item}
@@ -745,8 +744,7 @@ func TestEnsureDownstreamProviderConfigs(t *testing.T) {
 				return nil
 			},
 			MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
-				switch l := list.(type) {
-				case *unstructured.UnstructuredList:
+				if l, ok := list.(*unstructured.UnstructuredList); ok {
 					stale := unstructured.Unstructured{}
 					stale.SetName("stale-old-pc")
 					l.Items = []unstructured.Unstructured{stale}


### PR DESCRIPTION
## Summary
- Fix 2x `gocritic` singleCaseSwitch: replace single-case type switch with if-type-assertion
- Fix 2x `gofmt`: import sort order and struct tag alignment
- Fix 3x `staticcheck` QF1008: remove redundant embedded field `TLSClientConfig` from selectors

## Test plan
- [ ] CI golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)