### PR TITLE
fix: regenerate CRDs for clusterType field

### DIFF
--- a/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigs.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: clusterproviderconfigs.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com

--- a/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigusages.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigusages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: clusterproviderconfigusages.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com

--- a/package/crds/kubeconfig.stuttgart-things.com_providerconfigs.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_providerconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: providerconfigs.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com

--- a/package/crds/kubeconfig.stuttgart-things.com_providerconfigusages.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_providerconfigusages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: providerconfigusages.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com

--- a/package/crds/kubeconfig.stuttgart-things.com_remoteclusters.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_remoteclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: remoteclusters.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com
@@ -30,6 +30,9 @@ spec:
       type: string
     - jsonPath: .status.atProvider.serverVersion
       name: VERSION
+      type: string
+    - jsonPath: .status.atProvider.clusterType
+      name: TYPE
       type: string
     - jsonPath: .status.atProvider.internalNetworkKey
       name: NETWORK
@@ -201,6 +204,10 @@ spec:
                     type: string
                   clusterName:
                     description: ClusterName is the name of the remote cluster.
+                    type: string
+                  clusterType:
+                    description: ClusterType is the detected Kubernetes distribution
+                      (kind, k3s, rke2, k8s).
                     type: string
                   internalNetworkKey:
                     description: |-


### PR DESCRIPTION
## Summary
- Regenerate CRDs with `controller-gen` to include the `clusterType` field and `TYPE` printer column added in v0.9.0
- Without this, the field exists in Go types/controller but is absent from the deployed CRD

## Test plan
- [ ] Deploy updated provider — `kubectl get remotecluster` shows TYPE column
- [ ] `status.atProvider.clusterType` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)