### PR TITLE
fix: detect kind clusters with kind:// providerID

### DIFF
--- a/internal/cluster/info.go
+++ b/internal/cluster/info.go
@@ -143,9 +143,8 @@ func detectClusterType(serverVersion string, ctx context.Context, cs kubernetes.
 		for _, node := range nodes.Items {
 			// kind nodes have names like "{cluster}-control-plane" or "{cluster}-worker"
 			if strings.HasSuffix(node.Name, "-control-plane") || strings.HasSuffix(node.Name, "-worker") {
-				// Verify by checking the container runtime — kind uses containerd
-				// and the providerID is empty (no cloud provider)
-				if node.Spec.ProviderID == "" {
+				// kind sets providerID to "kind://..." or leaves it empty
+				if node.Spec.ProviderID == "" || strings.HasPrefix(node.Spec.ProviderID, "kind://") {
 					return "kind"
 				}
 			}

--- a/internal/cluster/info_test.go
+++ b/internal/cluster/info_test.go
@@ -99,6 +99,16 @@ func TestDetectClusterType(t *testing.T) {
 			},
 			want: "kind",
 		},
+		"KindWithProviderID": {
+			serverVersion: "v1.35.0",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "dev-control-plane"},
+					Spec:       corev1.NodeSpec{ProviderID: "kind://docker/dev/dev-control-plane"},
+				},
+			},
+			want: "kind",
+		},
 		"CloudNodeNotKind": {
 			serverVersion: "v1.35.0",
 			nodes: []corev1.Node{


### PR DESCRIPTION
## Summary
- Kind sets `providerID` to `kind://docker/...` on nodes, not empty string
- Previous detection only checked for empty providerID, causing kind clusters to be reported as `k8s`
- Now also matches `kind://` prefix
- Adds test case for kind nodes with providerID set

## Test plan
- [ ] Deploy to kind cluster — `kubectl get remotecluster` shows `TYPE=kind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)