### PR TITLE
fix: add missing Secret RBAC permissions

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -36,6 +36,10 @@ spec:
       - apiGroups: ["rbac.authorization.k8s.io"]
         resources: ["clusterroles", "clusterrolebindings"]
         verbs: ["create"]
+      # Kubeconfig + credential Secrets (create, read, update, delete)
+      - apiGroups: [""]
+        resources: ["secrets"]
+        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
       # Detect own pod for service account discovery
       - apiGroups: [""]
         resources: ["pods"]


### PR DESCRIPTION
## Summary
- Adds Secret (`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`) permissions to `package/crossplane.yaml`
- The provider controller manages kubeconfig Secrets, Git auth tokens, Vault credentials, and ArgoCD cluster Secrets but had no declared Secret RBAC

Closes #40

## Test plan
- [ ] CI build passes
- [ ] Verify new xpkg includes Secret rules: `crossplane xpkg content provider-kubeconfig.xpkg | grep -A2 secrets`
- [ ] Deploy upgraded provider on dev cluster and confirm Secret operations succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)