### PR TITLE
fix(decrypt): serialize SOPS_AGE_KEY to fix concurrent-decrypt race (#58)

### DIFF
--- a/internal/decrypt/decrypt.go
+++ b/internal/decrypt/decrypt.go
@@ -20,10 +20,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/getsops/sops/v3/decrypt"
 	"github.com/pkg/errors"
 )
+
+// sopsEnvMu serializes access to the process-global SOPS_AGE_KEY environment
+// variable. SOPS reads the age key from this env var, so without serialization
+// concurrent reconciles of RemoteClusters with different age keys can race:
+// one goroutine could overwrite the key while another is mid-decrypt, causing
+// sporadic decrypt failures or a key mismatch. Decryption is CPU-cheap and not
+// the reconcile hot path (git fetch is), so a global lock is an acceptable
+// mitigation. See issue #58.
+var sopsEnvMu sync.Mutex
 
 // SOPSDecrypt decrypts SOPS-encrypted data using the provided age key.
 // It detects the format from the file path extension.
@@ -31,6 +41,11 @@ func SOPSDecrypt(data []byte, filePath string, ageKey string) ([]byte, error) {
 	if ageKey == "" {
 		return nil, errors.New("age key is empty")
 	}
+
+	// Serialize the env-var set/decrypt/restore so concurrent callers with
+	// different keys cannot clobber each other's SOPS_AGE_KEY.
+	sopsEnvMu.Lock()
+	defer sopsEnvMu.Unlock()
 
 	// Set the age key for SOPS to pick up
 	prev := os.Getenv("SOPS_AGE_KEY")

--- a/internal/decrypt/decrypt_test.go
+++ b/internal/decrypt/decrypt_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package decrypt
 
 import (
+	"fmt"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -86,5 +89,33 @@ func TestSOPSDecryptInvalidData(t *testing.T) {
 	_, err := SOPSDecrypt([]byte("not-encrypted"), "file.yaml", "AGE-SECRET-KEY-FAKE")
 	if err == nil {
 		t.Fatal("expected error for non-SOPS data, got nil")
+	}
+}
+
+// TestSOPSDecryptConcurrentKeyIsolation is a regression test for issue #58:
+// concurrent decrypts with different age keys must not clobber the shared
+// SOPS_AGE_KEY env var. After all goroutines complete, the env var must be
+// restored to its original value. Without serialization, interleaved
+// save/restore can leak one goroutine's key into the process environment.
+// Run with -race to also catch any data race on the env var.
+func TestSOPSDecryptConcurrentKeyIsolation(t *testing.T) {
+	const original = "SENTINEL-ORIGINAL-KEY"
+	t.Setenv("SOPS_AGE_KEY", original)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			// Distinct key per goroutine; invalid data means decrypt errors,
+			// which is fine — we only care that the env var is not corrupted.
+			_, _ = SOPSDecrypt([]byte("not-encrypted"), "file.yaml", fmt.Sprintf("AGE-SECRET-KEY-%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	if got := os.Getenv("SOPS_AGE_KEY"); got != original {
+		t.Errorf("SOPS_AGE_KEY leaked after concurrent decrypts: want %q, got %q", original, got)
 	}
 }


### PR DESCRIPTION
Fixes #58.

`internal/decrypt/decrypt.go` sets the **process-global** `SOPS_AGE_KEY` env var around the SOPS decrypt call. Under concurrent `RemoteCluster` reconciles (default worker count > 1) with **different** age keys, one goroutine can overwrite the key while another is mid-decrypt — causing sporadic decrypt failures or, worst case, a key mismatch.

### Fix
Guard the `set → decrypt → restore` sequence with a package-level `sync.Mutex`. Decryption is CPU-cheap and not the reconcile hot path (git fetch is), so global serialization is an acceptable short-term mitigation (as suggested in the issue).

### Test
Adds `TestSOPSDecryptConcurrentKeyIsolation`: 50 goroutines decrypt concurrently with distinct keys, then asserts `SOPS_AGE_KEY` is restored to its original value. Without serialization, interleaved save/restore leaks a key. Passes under `go test -race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)