### PR TITLE
feat(git): pin kubeconfig source to a commit SHA or tag (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ spec:
   git:
     url: https://github.com/my-org/my-public-repo.git
     branch: main
+    # revision: v1.2.3   # optional: pin to a commit SHA or tag for
+    #                    # deterministic, rollback-friendly reconciles.
+    #                    # When set, the branch tip is ignored.
   decryption:
     provider: sops
     secretRef:

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -18,6 +18,12 @@ type GitConfig struct {
 	// Branch to use. Defaults to main.
 	// +kubebuilder:default=main
 	Branch string `json:"branch,omitempty"`
+	// Revision pins the checkout to a specific commit SHA or tag. When set,
+	// the branch tip is ignored and the kubeconfig is read from this exact
+	// revision, making reconciles deterministic and enabling rollback by
+	// changing the field rather than force-pushing the branch.
+	// +optional
+	Revision string `json:"revision,omitempty"`
 	// SecretRef references a secret with Git credentials (token or SSH key).
 	// +optional
 	SecretRef *SecretRef `json:"secretRef,omitempty"`

--- a/internal/controller/remotecluster/remotecluster.go
+++ b/internal/controller/remotecluster/remotecluster.go
@@ -417,13 +417,13 @@ func (c *external) readFromVault(ctx context.Context, path, key string) ([]byte,
 func (c *external) cloneAndReadFile(ctx context.Context, filePath string) ([]byte, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	repo := gitpkg.NewRepo(c.providerSpec.Git.URL, c.providerSpec.Git.Branch, c.gitToken)
+	repo := gitpkg.NewRepo(c.providerSpec.Git.URL, c.providerSpec.Git.Branch, c.providerSpec.Git.Revision, c.gitToken)
 
 	if _, err := repo.EnsureCloned(ctx); err != nil {
-		log.Info("Git clone/pull failed", "url", c.providerSpec.Git.URL, "branch", c.providerSpec.Git.Branch, "error", err)
+		log.Info("Git clone/pull failed", "url", c.providerSpec.Git.URL, "branch", c.providerSpec.Git.Branch, "revision", c.providerSpec.Git.Revision, "error", err)
 		return nil, errors.Wrap(err, errCloneRepo)
 	}
-	log.V(1).Info("Git repo ready", "url", c.providerSpec.Git.URL, "branch", c.providerSpec.Git.Branch)
+	log.V(1).Info("Git repo ready", "url", c.providerSpec.Git.URL, "branch", c.providerSpec.Git.Branch, "revision", c.providerSpec.Git.Revision)
 
 	content, err := repo.ReadFile(filePath)
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -51,18 +51,21 @@ func repoMutex(key string) *sync.Mutex {
 type Repo struct {
 	url      string
 	branch   string
+	revision string
 	token    string
 	cacheDir string
 }
 
-// NewRepo creates a Repo. The cache directory is derived deterministically from the URL.
-func NewRepo(url, branch, token string) *Repo {
+// NewRepo creates a Repo. The cache directory is derived deterministically from
+// the URL, branch and revision, so a pinned-revision checkout never collides
+// with the branch-tip cache for the same repo.
+func NewRepo(url, branch, revision, token string) *Repo {
 	if branch == "" {
 		branch = "main"
 	}
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(url+"@"+branch)))[:16]
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(url+"@"+branch+"#"+revision)))[:16]
 	cacheDir := filepath.Join(os.TempDir(), "provider-kubeconfig", hash)
-	return &Repo{url: url, branch: branch, token: token, cacheDir: cacheDir}
+	return &Repo{url: url, branch: branch, revision: revision, token: token, cacheDir: cacheDir}
 }
 
 func (r *Repo) auth() *http.BasicAuth {
@@ -75,11 +78,17 @@ func (r *Repo) auth() *http.BasicAuth {
 	}
 }
 
-// EnsureCloned clones the repo if not cached, or pulls latest if it is.
+// EnsureCloned clones the repo if not cached, or pulls latest if it is. When a
+// revision is pinned it delegates to ensureRevision, which checks out the exact
+// commit/tag instead of tracking the branch tip.
 func (r *Repo) EnsureCloned(ctx context.Context) (string, error) {
 	mu := repoMutex(r.cacheDir)
 	mu.Lock()
 	defer mu.Unlock()
+
+	if r.revision != "" {
+		return r.ensureRevision(ctx)
+	}
 
 	refName := plumbing.NewBranchReferenceName(r.branch)
 
@@ -108,6 +117,49 @@ func (r *Repo) EnsureCloned(ctx context.Context) (string, error) {
 		// Clean up partial clone on failure
 		_ = os.RemoveAll(r.cacheDir)
 		return "", errors.Wrap(err, "cannot clone git repository")
+	}
+
+	return r.cacheDir, nil
+}
+
+// ensureRevision clones the full repository (no shallow/single-branch limits, so
+// an arbitrary commit SHA or tag is resolvable) and checks out the pinned
+// revision. The revision is treated as immutable: because the cache key embeds
+// it, an existing cache is reused as-is without fetching.
+func (r *Repo) ensureRevision(ctx context.Context) (string, error) {
+	if _, err := os.Stat(filepath.Join(r.cacheDir, ".git")); err == nil {
+		return r.cacheDir, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(r.cacheDir), 0750); err != nil {
+		return "", errors.Wrap(err, "cannot create cache parent directory")
+	}
+
+	repo, err := git.PlainCloneContext(ctx, r.cacheDir, false, &git.CloneOptions{
+		URL:  r.url,
+		Auth: r.auth(),
+		Tags: git.AllTags,
+	})
+	if err != nil {
+		_ = os.RemoveAll(r.cacheDir)
+		return "", errors.Wrap(err, "cannot clone git repository")
+	}
+
+	hash, err := repo.ResolveRevision(plumbing.Revision(r.revision))
+	if err != nil {
+		_ = os.RemoveAll(r.cacheDir)
+		return "", errors.Wrapf(err, "cannot resolve git revision %q", r.revision)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		_ = os.RemoveAll(r.cacheDir)
+		return "", errors.Wrap(err, "cannot get worktree")
+	}
+
+	if err := wt.Checkout(&git.CheckoutOptions{Hash: *hash}); err != nil {
+		_ = os.RemoveAll(r.cacheDir)
+		return "", errors.Wrapf(err, "cannot checkout git revision %q", r.revision)
 	}
 
 	return r.cacheDir, nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -26,10 +26,11 @@ import (
 
 func TestNewRepo(t *testing.T) {
 	cases := map[string]struct {
-		url    string
-		branch string
-		token  string
-		wantBr string
+		url      string
+		branch   string
+		revision string
+		token    string
+		wantBr   string
 	}{
 		"DefaultBranch": {
 			url:    "https://github.com/example/repo.git",
@@ -41,11 +42,17 @@ func TestNewRepo(t *testing.T) {
 			branch: "develop",
 			wantBr: "develop",
 		},
+		"PinnedRevision": {
+			url:      "https://github.com/example/repo.git",
+			branch:   "main",
+			revision: "v1.2.3",
+			wantBr:   "main",
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewRepo(tc.url, tc.branch, tc.token)
+			r := NewRepo(tc.url, tc.branch, tc.revision, tc.token)
 			if diff := cmp.Diff(tc.wantBr, r.branch); diff != "" {
 				t.Errorf("branch: -want, +got:\n%s", diff)
 			}
@@ -60,9 +67,9 @@ func TestNewRepo(t *testing.T) {
 }
 
 func TestNewRepoDeterministicCacheDir(t *testing.T) {
-	r1 := NewRepo("https://github.com/example/repo.git", "main", "")
-	r2 := NewRepo("https://github.com/example/repo.git", "main", "")
-	r3 := NewRepo("https://github.com/example/other.git", "main", "")
+	r1 := NewRepo("https://github.com/example/repo.git", "main", "", "")
+	r2 := NewRepo("https://github.com/example/repo.git", "main", "", "")
+	r3 := NewRepo("https://github.com/example/other.git", "main", "", "")
 
 	if r1.cacheDir != r2.cacheDir {
 		t.Errorf("same URL should produce same cacheDir: %q vs %q", r1.cacheDir, r2.cacheDir)
@@ -71,14 +78,25 @@ func TestNewRepoDeterministicCacheDir(t *testing.T) {
 		t.Errorf("different URLs should produce different cacheDirs: %q vs %q", r1.cacheDir, r3.cacheDir)
 	}
 
-	r4 := NewRepo("https://github.com/example/repo.git", "develop", "")
+	r4 := NewRepo("https://github.com/example/repo.git", "develop", "", "")
 	if r1.cacheDir == r4.cacheDir {
 		t.Errorf("different branches should produce different cacheDirs: %q vs %q", r1.cacheDir, r4.cacheDir)
+	}
+
+	// A pinned revision must not collide with the branch-tip cache, and
+	// different revisions must map to different cache dirs.
+	r5 := NewRepo("https://github.com/example/repo.git", "main", "v1.0.0", "")
+	r6 := NewRepo("https://github.com/example/repo.git", "main", "v2.0.0", "")
+	if r1.cacheDir == r5.cacheDir {
+		t.Errorf("pinned revision should not collide with branch-tip cacheDir: %q", r5.cacheDir)
+	}
+	if r5.cacheDir == r6.cacheDir {
+		t.Errorf("different revisions should produce different cacheDirs: %q vs %q", r5.cacheDir, r6.cacheDir)
 	}
 }
 
 func TestAuth(t *testing.T) {
-	r := NewRepo("https://github.com/example/repo.git", "", "my-token")
+	r := NewRepo("https://github.com/example/repo.git", "", "", "my-token")
 	auth := r.auth()
 	if auth == nil {
 		t.Fatal("expected auth to be non-nil when token is set")
@@ -90,7 +108,7 @@ func TestAuth(t *testing.T) {
 		t.Errorf("password: want %q, got %q", "my-token", auth.Password)
 	}
 
-	r2 := NewRepo("https://github.com/example/repo.git", "", "")
+	r2 := NewRepo("https://github.com/example/repo.git", "", "", "")
 	if r2.auth() != nil {
 		t.Error("expected nil auth when token is empty")
 	}

--- a/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigs.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterproviderconfigs.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com
@@ -84,6 +84,13 @@ spec:
                   branch:
                     default: main
                     description: Branch to use. Defaults to main.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision pins the checkout to a specific commit SHA or tag. When set,
+                      the branch tip is ignored and the kubeconfig is read from this exact
+                      revision, making reconciles deterministic and enabling rollback by
+                      changing the field rather than force-pushing the branch.
                     type: string
                   secretRef:
                     description: SecretRef references a secret with Git credentials

--- a/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigusages.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_clusterproviderconfigusages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterproviderconfigusages.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com

--- a/package/crds/kubeconfig.stuttgart-things.com_providerconfigs.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_providerconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: providerconfigs.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com
@@ -84,6 +84,13 @@ spec:
                   branch:
                     default: main
                     description: Branch to use. Defaults to main.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision pins the checkout to a specific commit SHA or tag. When set,
+                      the branch tip is ignored and the kubeconfig is read from this exact
+                      revision, making reconciles deterministic and enabling rollback by
+                      changing the field rather than force-pushing the branch.
                     type: string
                   secretRef:
                     description: SecretRef references a secret with Git credentials

--- a/package/crds/kubeconfig.stuttgart-things.com_providerconfigusages.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_providerconfigusages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: providerconfigusages.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com

--- a/package/crds/kubeconfig.stuttgart-things.com_remoteclusters.yaml
+++ b/package/crds/kubeconfig.stuttgart-things.com_remoteclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: remoteclusters.kubeconfig.stuttgart-things.com
 spec:
   group: kubeconfig.stuttgart-things.com
@@ -307,6 +307,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile-requested-at annotation token that the controller has
+                  processed. Users can compare this to the annotation to determine
+                  whether a reconcile request has been handled.
+                type: string
               observedGeneration:
                 description: |-
                   ObservedGeneration is the latest metadata.generation


### PR DESCRIPTION
Closes #59.

`GitConfig` only exposed `url` + `branch`, so `EnsureCloned` always shallow-cloned the **branch tip** — reconciles were non-deterministic (whatever's on the branch wins) and rollback required force-pushing the branch.

### Change
Add an optional **`GitConfig.Revision`** field (commit SHA or tag):

- When **unset**: unchanged behavior (shallow single-branch clone + pull).
- When **set**: `ensureRevision` does a full clone (so any SHA/tag is resolvable), resolves it via go-git `ResolveRevision`, and checks out that exact object. The revision is treated as **immutable** and folded into the cache-key hash, so:
  - a pinned checkout never collides with the branch-tip cache for the same repo, and
  - an already-cached revision is reused without re-fetching.

### CRD regen
Regenerated with controller-gen **v0.21.0**. Beyond the new `revision` field, the diff includes catch-up regen the earlier dep PRs didn't run:
- `controller-gen.kubebuilder.io/version` annotation `v0.20.1` → `v0.21.0`
- `RemoteCluster` status gains `lastHandledReconcileAt` (from the crossplane-runtime v2.3.2 `core/v2` status type)

These keep the committed CRDs in sync with the current code/tooling.

### Tests
- `TestNewRepo` / `TestNewRepoDeterministicCacheDir` extended: a pinned revision maps to a distinct cache dir, and different revisions don't collide.
- README documents the field with an inline example.

`go build`/`test`/`vet` and `golangci-lint` (pinned v2.11.4) all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)