### PR TITLE
fix(git): private cache dir, LRU eviction, configurable location (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,15 @@ The provider bootstraps its own RBAC on startup to manage downstream ProviderCon
 
 This is automatic — no manual RBAC setup required. On provider upgrades (new pod/SA name), the bootstrap appends the new SA to the binding.
 
+## Git Cache
+
+Git sources are cloned into a per-repo cache directory. The cache root is created with `0700` permissions so cached repo contents (kubeconfigs, `.git`) are not readable by other users sharing the pod. Least-recently-used directories are evicted once the entry count exceeds a cap, bounding disk usage on long-running pods.
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `PROVIDER_KUBECONFIG_CACHE_DIR` | `$XDG_CACHE_HOME/provider-kubeconfig` (else `$TMPDIR/provider-kubeconfig`) | Cache root. Point at a dedicated writable volume (e.g. an `emptyDir`) to keep clones off shared `/tmp`. |
+| `PROVIDER_KUBECONFIG_CACHE_MAX_ENTRIES` | `32` | Max cached repo directories retained before LRU eviction. |
+
 ## Building
 
 ### Prerequisites

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -22,7 +22,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -30,11 +33,125 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// envCacheDir overrides the cache root location. Point it at a dedicated
+	// writable volume (e.g. an emptyDir) to keep cached repos off the node's
+	// shared /tmp.
+	envCacheDir = "PROVIDER_KUBECONFIG_CACHE_DIR"
+	// envMaxCacheEntries overrides the maximum number of cached repo
+	// directories retained before least-recently-used eviction kicks in.
+	envMaxCacheEntries = "PROVIDER_KUBECONFIG_CACHE_MAX_ENTRIES"
+	// defaultMaxCacheEntries bounds the cache so a long-running pod that
+	// reconciles many distinct repos does not grow the cache without limit.
+	defaultMaxCacheEntries = 32
+	// cacheDirPerm keeps cached repo contents (kubeconfigs, .git) unreadable by
+	// other users sharing the pod.
+	cacheDirPerm = 0o700
+)
+
 var (
 	// muMap guards concurrent access to the same repo cache directory.
 	muMap   = make(map[string]*sync.Mutex)
 	muMapMu sync.Mutex
 )
+
+// cacheRoot returns the root directory under which per-repo caches live. It
+// prefers an explicit override, then the user cache dir, falling back to the
+// system temp dir. The root is always created with 0700 permissions.
+func cacheRoot() string {
+	if v := os.Getenv(envCacheDir); v != "" {
+		return v
+	}
+	if dir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(dir, "provider-kubeconfig")
+	}
+	return filepath.Join(os.TempDir(), "provider-kubeconfig")
+}
+
+// ensureCacheRoot creates the cache root with private permissions, enforcing
+// 0700 even when the process umask would otherwise widen it.
+func ensureCacheRoot(root string) error {
+	if err := os.MkdirAll(root, cacheDirPerm); err != nil {
+		return errors.Wrap(err, "cannot create cache root directory")
+	}
+	if err := os.Chmod(root, cacheDirPerm); err != nil {
+		return errors.Wrap(err, "cannot set cache root permissions")
+	}
+	return nil
+}
+
+// maxCacheEntries returns the configured cache entry cap, or the default.
+func maxCacheEntries() int {
+	if v := os.Getenv(envMaxCacheEntries); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxCacheEntries
+}
+
+type cacheEntry struct {
+	path string
+	mod  time.Time
+}
+
+// cacheEntriesByAge lists the subdirectories of root, sorted least-recently-used
+// (oldest mtime) first. Returns nil on any read error.
+func cacheEntriesByAge(root string) []cacheEntry {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	dirs := make([]cacheEntry, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		dirs = append(dirs, cacheEntry{path: filepath.Join(root, e.Name()), mod: info.ModTime()})
+	}
+	sort.Slice(dirs, func(i, j int) bool { return dirs[i].mod.Before(dirs[j].mod) })
+	return dirs
+}
+
+// evictCache bounds root to at most maxEntries directories, removing the
+// least-recently-used entries beyond the limit. Directories currently locked by
+// an in-flight reconcile are skipped (TryLock), and keep is never removed.
+// Best-effort: any error leaves the cache as-is.
+func evictCache(root, keep string, maxEntries int) {
+	dirs := cacheEntriesByAge(root)
+	excess := len(dirs) - maxEntries
+	if excess <= 0 {
+		return
+	}
+
+	for _, d := range dirs {
+		if excess <= 0 {
+			break
+		}
+		if d.path == keep {
+			continue
+		}
+		mu := repoMutex(d.path)
+		if !mu.TryLock() {
+			continue // another reconcile is using this directory
+		}
+		if err := os.RemoveAll(d.path); err == nil {
+			excess--
+		}
+		mu.Unlock()
+	}
+}
+
+// touch updates a directory's mtime so recently-used caches sort as newest for
+// eviction purposes (LRU).
+func touch(path string) {
+	now := time.Now()
+	_ = os.Chtimes(path, now, now)
+}
 
 func repoMutex(key string) *sync.Mutex {
 	muMapMu.Lock()
@@ -64,7 +181,7 @@ func NewRepo(url, branch, revision, token string) *Repo {
 		branch = "main"
 	}
 	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(url+"@"+branch+"#"+revision)))[:16]
-	cacheDir := filepath.Join(os.TempDir(), "provider-kubeconfig", hash)
+	cacheDir := filepath.Join(cacheRoot(), hash)
 	return &Repo{url: url, branch: branch, revision: revision, token: token, cacheDir: cacheDir}
 }
 
@@ -80,12 +197,26 @@ func (r *Repo) auth() *http.BasicAuth {
 
 // EnsureCloned clones the repo if not cached, or pulls latest if it is. When a
 // revision is pinned it delegates to ensureRevision, which checks out the exact
-// commit/tag instead of tracking the branch tip.
+// commit/tag instead of tracking the branch tip. On success it marks the cache
+// as recently used and evicts least-recently-used entries beyond the cap.
 func (r *Repo) EnsureCloned(ctx context.Context) (string, error) {
 	mu := repoMutex(r.cacheDir)
 	mu.Lock()
 	defer mu.Unlock()
 
+	dir, err := r.ensure(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	touch(dir)
+	evictCache(filepath.Dir(r.cacheDir), r.cacheDir, maxCacheEntries())
+	return dir, nil
+}
+
+// ensure performs the clone/pull (or pinned-revision checkout) and returns the
+// cache directory, without the LRU bookkeeping handled by EnsureCloned.
+func (r *Repo) ensure(ctx context.Context) (string, error) {
 	if r.revision != "" {
 		return r.ensureRevision(ctx)
 	}
@@ -101,8 +232,8 @@ func (r *Repo) EnsureCloned(ctx context.Context) (string, error) {
 		_ = os.RemoveAll(r.cacheDir)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(r.cacheDir), 0750); err != nil {
-		return "", errors.Wrap(err, "cannot create cache parent directory")
+	if err := ensureCacheRoot(filepath.Dir(r.cacheDir)); err != nil {
+		return "", err
 	}
 
 	opts := &git.CloneOptions{
@@ -131,8 +262,8 @@ func (r *Repo) ensureRevision(ctx context.Context) (string, error) {
 		return r.cacheDir, nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(r.cacheDir), 0750); err != nil {
-		return "", errors.Wrap(err, "cannot create cache parent directory")
+	if err := ensureCacheRoot(filepath.Dir(r.cacheDir)); err != nil {
+		return "", err
 	}
 
 	repo, err := git.PlainCloneContext(ctx, r.cacheDir, false, &git.CloneOptions{

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package git
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -111,6 +118,133 @@ func TestAuth(t *testing.T) {
 	r2 := NewRepo("https://github.com/example/repo.git", "", "", "")
 	if r2.auth() != nil {
 		t.Error("expected nil auth when token is empty")
+	}
+}
+
+func TestEvictCacheLRU(t *testing.T) {
+	root := t.TempDir()
+	base := time.Unix(1_000_000, 0)
+	paths := make([]string, 5)
+	for i := range paths {
+		p := filepath.Join(root, fmt.Sprintf("r%d", i))
+		if err := os.MkdirAll(p, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		mt := base.Add(time.Duration(i) * time.Hour)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+		paths[i] = p
+	}
+
+	// Cap to 2 entries, keeping the newest. The 3 oldest must be evicted.
+	evictCache(root, paths[4], 2)
+
+	exists := func(p string) bool { _, err := os.Stat(p); return err == nil }
+	for _, i := range []int{0, 1, 2} {
+		if exists(paths[i]) {
+			t.Errorf("expected LRU entry %s to be evicted", paths[i])
+		}
+	}
+	for _, i := range []int{3, 4} {
+		if !exists(paths[i]) {
+			t.Errorf("expected recent entry %s to be retained", paths[i])
+		}
+	}
+}
+
+func TestEvictCacheSkipsLocked(t *testing.T) {
+	root := t.TempDir()
+	base := time.Unix(1_000_000, 0)
+	paths := make([]string, 3)
+	for i := range paths {
+		p := filepath.Join(root, fmt.Sprintf("r%d", i))
+		if err := os.MkdirAll(p, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		mt := base.Add(time.Duration(i) * time.Hour)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+		paths[i] = p
+	}
+
+	// Lock the oldest entry: eviction must skip it even though it is the
+	// least-recently-used, because another reconcile is using it.
+	mu := repoMutex(paths[0])
+	mu.Lock()
+	defer mu.Unlock()
+
+	evictCache(root, "", 1)
+
+	if _, err := os.Stat(paths[0]); err != nil {
+		t.Error("locked dir must not be evicted")
+	}
+	if _, err := os.Stat(paths[1]); err == nil {
+		t.Error("unlocked LRU dir should have been evicted")
+	}
+}
+
+// initSourceRepo creates a local non-bare git repo with one commit on `main`
+// and returns its path and the commit hash.
+func initSourceRepo(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInitWithOptions(dir, &git.PlainInitOptions{
+		InitOptions: git.InitOptions{DefaultBranch: plumbing.NewBranchReferenceName("main")},
+	})
+	if err != nil {
+		t.Fatalf("init source repo: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "kubeconfig.yaml"), []byte("data"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, err := wt.Add("kubeconfig.yaml"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	h, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example.com", When: time.Unix(0, 0)},
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return dir, h.String()
+}
+
+func TestEnsureClonedPrivateCacheAndNoCredentialLeak(t *testing.T) {
+	src, hash := initSourceRepo(t)
+
+	// Point the cache at a not-yet-existing dir so ensureCacheRoot must create
+	// it, and we can assert the permissions it applies.
+	root := filepath.Join(t.TempDir(), "cache")
+	t.Setenv(envCacheDir, root)
+
+	const token = "SUPER-SECRET-TOKEN"
+	// Pin to the commit hash so the (local-friendly) full-clone path runs.
+	r := NewRepo(src, "main", hash, token)
+	dir, err := r.EnsureCloned(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureCloned: %v", err)
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		t.Fatalf("stat cache root: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != cacheDirPerm {
+		t.Errorf("cache root permissions: want %#o, got %#o", cacheDirPerm, perm)
+	}
+
+	cfg, err := os.ReadFile(filepath.Join(dir, ".git", "config")) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("read .git/config: %v", err)
+	}
+	if strings.Contains(string(cfg), token) {
+		t.Error(".git/config leaked the access token")
 	}
 }
 


### PR DESCRIPTION
Closes #61.

The git cache was cloned under a world-readable `/tmp/provider-kubeconfig/...` path, created `0750`, with **no eviction** — every unique repo+branch+revision left a directory for the pod's lifetime.

### Changes
- **Permissions:** cache root is created `0700` (enforced via `Chmod` to beat the umask), so cached kubeconfigs and `.git` aren't readable by other users sharing the pod.
- **Location:** default root moves to `os.UserCacheDir()` (falling back to the temp dir). New `PROVIDER_KUBECONFIG_CACHE_DIR` env var points it at a dedicated writable volume (e.g. an `emptyDir`).
- **Eviction:** LRU bound via `PROVIDER_KUBECONFIG_CACHE_MAX_ENTRIES` (default 32). Each access touches the dir mtime; `EnsureCloned` evicts the oldest entries beyond the cap. Eviction **skips directories locked by an in-flight reconcile** (`TryLock`) and never removes the just-used dir, so it's concurrency-safe.

### Tests
- `TestEvictCacheLRU` — oldest-first removal, recent + kept entries retained.
- `TestEvictCacheSkipsLocked` — a locked (in-use) dir is never evicted.
- `TestEnsureClonedPrivateCacheAndNoCredentialLeak` — real local clone asserts the cache root is `0700` and the access token is **not** persisted to `.git/config` (addresses the issue's credential-leak check).

README documents the two env vars. `go build`/`test -race`/`vet` and `golangci-lint` (pinned v2.11.4) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)